### PR TITLE
Add ClearScript V8 packages to project

### DIFF
--- a/VSExtension1/VSExtension1.csproj
+++ b/VSExtension1/VSExtension1.csproj
@@ -8,6 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="MessagePack" Version="3.1.1" />
+    <PackageReference Include="Microsoft.ClearScript.V8" Version="7.4.5" />
+    <PackageReference Include="Microsoft.ClearScript.V8.Native.win-x64" Version="7.4.5" />
     <PackageReference Include="Microsoft.VisualStudio.Extensibility.Sdk" Version="17.12.40390" />
     <PackageReference Include="Microsoft.VisualStudio.Extensibility.Build" Version="17.12.40390" />
   </ItemGroup>

--- a/VSExtension1/packages.lock.json
+++ b/VSExtension1/packages.lock.json
@@ -13,6 +13,23 @@
           "Microsoft.NET.StringTools": "17.11.4"
         }
       },
+      "Microsoft.ClearScript.V8": {
+        "type": "Direct",
+        "requested": "[7.4.5, )",
+        "resolved": "7.4.5",
+        "contentHash": "/czu8ho8xEiiLF806QP6Iwgp0aN5QE1B/MsXnIIMxiaM/KccD8AfSsM68lVuyW+boGqjF7zjoSlUKs/ERUoLOQ==",
+        "dependencies": {
+          "Microsoft.ClearScript.Core": "7.4.5",
+          "Microsoft.ClearScript.V8.ICUData": "7.4.5",
+          "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "Microsoft.ClearScript.V8.Native.win-x64": {
+        "type": "Direct",
+        "requested": "[7.4.5, )",
+        "resolved": "7.4.5",
+        "contentHash": "LvsaJoVgcf09FJ6mZ6SIptdeuwmy42s1N2sMVO3Wqp+HAta7PPksxVh8cGelrGQmmW1C5hT1Jzc6ykxrzU4Adg=="
+      },
       "Microsoft.VisualStudio.Extensibility.Build": {
         "type": "Direct",
         "requested": "[17.12.40390, )",
@@ -95,6 +112,16 @@
         "type": "Transitive",
         "resolved": "8.0.0",
         "contentHash": "3WA9q9yVqJp222P3x1wYIGDAkpjAku0TMUaaQV22g6L67AI0LdOIrVS7Ht2vJfLHGSPVuqN94vIr15qn+HEkHw=="
+      },
+      "Microsoft.ClearScript.Core": {
+        "type": "Transitive",
+        "resolved": "7.4.5",
+        "contentHash": "CIZCty2L4mXy1xg77IbNPqsz2pS0ZsFVJZ5YolPB4j62xzvDuCFU/MKnTnKve67FGIWaB9w4LVV7YUEFmjEwzw=="
+      },
+      "Microsoft.ClearScript.V8.ICUData": {
+        "type": "Transitive",
+        "resolved": "7.4.5",
+        "contentHash": "Ji6av4T2xtqZYp5Gm0MPxvez5V6s4NF/wflD8a49A/KOI3kJyPHcmL3xCRuhuHo24NbfQX6+f0YbTdwhd5VSvw=="
       },
       "Microsoft.CSharp": {
         "type": "Transitive",


### PR DESCRIPTION
#### PR Classification
New feature: Added support for ClearScript V8.

#### PR Summary
This pull request adds support for ClearScript V8 by including necessary package references and updating dependencies.
- `VSExtension1.csproj`: Added `Microsoft.ClearScript.V8` and `Microsoft.ClearScript.V8.Native.win-x64` package references.
- `packages.lock.json`: Updated to include new packages and their transitive dependencies.
