### PR TITLE
Add FUNDING.yml to configure GitHub sponsor button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,9 @@
+# FUNDING.yml - GitHub sponsor button configuration
+# Copyright (C) 2024 Kaz Nishimura
+#
+# Copying and distribution of this file, with or without modification, are
+# permitted in any medium without royalty provided the copyright notice and
+# this notice are preserved. This file is offered as-is, without any warranty.
+---
+github:
+  - kazssym


### PR DESCRIPTION
#### PR Classification
New feature to configure the GitHub sponsor button.

#### PR Summary
Introduced a `FUNDING.yml` file to set up the GitHub sponsor button and included legal notices.
- Added `FUNDING.yml` with GitHub user `kazssym` as a sponsor option.
- Included a copyright notice for 2024 by Kaz Nishimura.
- Specified terms for copying and distribution of the file.
- Indicated the file is offered as-is, without any warranty.
