### PR TITLE
Update setup-msbuild action to v2 in msbuild.yml

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -34,7 +34,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v2
 
     - uses: actions/cache@v4
       with:


### PR DESCRIPTION
#### PR Classification
Version update for GitHub Actions workflow.

#### PR Summary
Updated the GitHub Actions workflow configuration for MSBuild to use the latest version of the `microsoft/setup-msbuild` action.
- `msbuild.yml`: Changed `microsoft/setup-msbuild` action version from `v1.0.2` to `v2`.
