### PR TITLE
Integrate a JavaScript engine into the Visual Studio extension

### DIFF
--- a/VSExtension1/GlobalObject.cs
+++ b/VSExtension1/GlobalObject.cs
@@ -1,0 +1,19 @@
+using Microsoft.VisualStudio.Extensibility;
+
+
+namespace VSExtension1
+{
+    internal class GlobalObject
+    {
+        private readonly VisualStudioExtensibility _extensibility;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GlobalObject"/> class.
+        /// </summary>
+        /// <param name="extensibility">The Visual Studio extensibility object.</param>
+        public GlobalObject(VisualStudioExtensibility extensibility)
+        {
+            this._extensibility = extensibility;
+        }
+    }
+}

--- a/VSExtension1/VSExtension1.csproj
+++ b/VSExtension1/VSExtension1.csproj
@@ -5,6 +5,20 @@
     <Nullable>enable</Nullable>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>$(NoWarn);VSEXTPREVIEW_OUTPUTWINDOW</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <NoWarn>$(NoWarn);VSEXTPREVIEW_OUTPUTWINDOW</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Remove="scripts\__init__.js" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="scripts\__init__.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="MessagePack" Version="3.1.1" />
@@ -12,5 +26,20 @@
     <PackageReference Include="Microsoft.ClearScript.V8.Native.win-x64" Version="7.4.5" />
     <PackageReference Include="Microsoft.VisualStudio.Extensibility.Sdk" Version="17.12.40390" />
     <PackageReference Include="Microsoft.VisualStudio.Extensibility.Build" Version="17.12.40390" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Update="Strings.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Strings.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Update="Strings.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Strings.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/VSExtension1/scripts/__init__.js
+++ b/VSExtension1/scripts/__init__.js
@@ -1,0 +1,3 @@
+// "__init__.js"
+
+// This file will be used to initialize the ScriptEngine.


### PR DESCRIPTION
#### PR Classification
New feature to integrate a JavaScript engine into the Visual Studio extension.

#### PR Summary
This pull request introduces a new JavaScript engine using ClearScript and V8 to the Visual Studio extension.
- `ExtensionEntrypoint.cs`: Added `CreateScriptEngine` method and updated `InitializeServices` to include the `ScriptEngine`.
- `GlobalObject.cs`: Added a new class to expose the `VisualStudioExtensibility` object to the script engine.
- `VSExtension1.csproj`: Updated to handle warnings, manage the `__init__.js` script file, and embed resource files.
- Added `__init__.js` script for initializing the `ScriptEngine`.
