### PR TITLE
Add copyright notice and AGPL license to GlobalObject.cs

### DIFF
--- a/VSExtension1/GlobalObject.cs
+++ b/VSExtension1/GlobalObject.cs
@@ -1,3 +1,22 @@
+// GlobalObject.cs
+// Copyright (C) 2025 Kaz Nishimura
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License
+// for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+
 using Microsoft.VisualStudio.Extensibility;
 
 


### PR DESCRIPTION
#### PR Classification
Documentation update to include licensing information.

#### PR Summary
Added copyright notice and licensing information to `GlobalObject.cs`.
- `GlobalObject.cs`: Added copyright notice, AGPL-3.0-or-later license information, disclaimer of warranties, and reference to the full license text.
